### PR TITLE
Set required "catalog" version to 0.4.0-alpha (Issue #29)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "7.0.*",
-        "lizards-and-pumpkins/catalog": "0.3.0-alpha"
+        "lizards-and-pumpkins/catalog": "0.4.0-alpha"
     },
     "require-dev": {
         "phpunit/phpunit": "5.3.*",


### PR DESCRIPTION
Closes #29.